### PR TITLE
Prevent underflow in tag reader

### DIFF
--- a/src/MACLib/APETag.cpp
+++ b/src/MACLib/APETag.cpp
@@ -504,7 +504,8 @@ int CAPETag::LoadField(const char * pBuffer, int nMaximumBytes, int * pBytes)
     
     // safety check (so we can't get buffer overflow attacked)
     int nMaximumRead = nMaximumBytes - 8 - nFieldValueSize;
-    BOOL bSafe = TRUE;
+    // guard against underflow
+    BOOL bSafe = nMaximumRead > 0;
     for (int z = 0; (z < nMaximumRead) && (bSafe == TRUE); z++)
     {
         int nCharacter = pBuffer[nLocation + z];


### PR DESCRIPTION
mac was segfaulting any time i pointed it at one particular .ape file.  Some debugging output:

```
#0  0x00007ffff7086664 in __memmove_avx_unaligned_erms () from /usr/lib/libc.so.6
#1  0x0000555555567183 in CAPETag::LoadField (this=0x5555557bee10, pBuffer=0x5555557980e7 "", nMaximumBytes=-20, pBytes=0x7fffffffd8d4)
    at /home/src/monkeys-audio/src/MACLib/APETag.cpp:528
#2  0x00005555555665b9 in CAPETag::Analyze (this=0x5555557bee10) at /home/src/monkeys-audio/src/MACLib/APETag.cpp:275
#3  0x0000555555565bbf in CAPETag::CAPETag (this=0x5555557bee10, pIO=0x5555557bada0, bAnalyze=1) at /home/src/monkeys-audio/src/MACLib/APETag.cpp:105
#4  0x000055555556f4a3 in CAPEInfo::CAPEInfo (this=0x5555557bacd0, pErrorCode=0x7fffffffdaac, pFilename=0x555555796e70 L"../bcast.ape", pTag=0x0)
    at /home/src/monkeys-audio/src/MACLib/APEInfo.cpp:46
#5  0x0000555555568554 in CreateIAPEDecompress (pFilename=0x555555796e70 L"../bcast.ape", pErrorCode=0x7fffffffdf6c)
    at /home/src/monkeys-audio/src/MACLib/MACLib.cpp:78
#6  0x0000555555563adb in DecompressCore (pInputFilename=0x555555796e70 L"../bcast.ape", pOutputFilename=0x0, nOutputMode=0, nCompressionLevel=-1,
    pPercentageDone=0x7fffffffe1b4, ProgressCallback=0x55555556139f <ProgressCallback(int)>, pKillFlag=0x7fffffffe1f0)
    at /home/src/monkeys-audio/src/MACLib/APESimple.cpp:290
#7  0x0000555555563828 in VerifyFileW (pInputFilename=0x555555796e70 L"../bcast.ape", pPercentageDone=0x7fffffffe1b4,
    ProgressCallback=0x55555556139f <ProgressCallback(int)>, pKillFlag=0x7fffffffe1f0, bQuickVerifyIfPossible=0)
    at /home/src/monkeys-audio/src/MACLib/APESimple.cpp:241
#8  0x00005555555619fd in main (argc=3, argv=0x7fffffffe318) at /home/src/monkeys-audio/src/Console/Console.cpp:209
(gdb) up
#1  0x0000555555567183 in CAPETag::LoadField (this=0x5555557bee10, pBuffer=0x5555557980e7 "", nMaximumBytes=-20, pBytes=0x7fffffffd8d4)
    at /home/src/monkeys-audio/src/MACLib/APETag.cpp:528
528         memcpy(spFieldBuffer, &pBuffer[nLocation], nFieldValueSize);
(gdb) info locals
nLocation = 9
nFieldValueSize = 2038494976
nFieldFlags = 5592405
nMaximumRead = -2038495004
bSafe = 1
nNameCharacters = 0
spNameUTF8 = {m_pObject = 0x555555799050 "", m_bArray = 1, m_bDelete = 1}
spNameUTF16 = {m_pObject = 0x5555557bf650 L"", m_bArray = 1, m_bDelete = 1}
spFieldBuffer = {m_pObject = 0x7fff7d501010 "", m_bArray = 1, m_bDelete = 1}
(gdb) up
#2  0x00005555555665b9 in CAPETag::Analyze (this=0x5555557bee10) at /home/src/monkeys-audio/src/MACLib/APETag.cpp:275
275                             if (LoadField(&spRawTag[nLocation], nMaximumFieldBytes, &nBytes) != ERROR_SUCCESS)
(gdb) info locals
nMaximumFieldBytes = -20
nBytes = 0
z = 6
nLocation = 135
nRawFieldBytes = 115
spRawTag = {m_pObject = 0x555555798060 "\017", m_bArray = 1, m_bDelete = 1}
APETagFooter = {m_cID = "APETAGEX", m_nVersion = 2000, m_nSize = 147, m_nFields = 33, m_nFlags = -2147483648, m_cReserved = "\000\000\000\000\000\000\000"}
ID3Tag = {Header = "& N", Title = "on-Work\t\000\000\000\000\000\000\000Album Artist\000Br",
  Artist = "oadcast\004\000\000\000\000\000\000\000Year\000\062\060\060\060\027\000\000\000\000", Album = "\000\000Comment\000ExactAudioCopy v0.99", Year = "pb4A",
  Comment = "PETAGEX\320\a\000\000\223\000\000\000!\000\000\000\000\000\000\200\000\000\000\000\000", Track = 0 '\000', Genre = 0 '\000'}
nOriginalPosition = 11412
nBytesRead = 115
nRetVal = 0
```

The tags here are completely broken (I can fix those by hand I suppose), but I was getting nowhere due to the crash.